### PR TITLE
Add invalid rate to stats

### DIFF
--- a/libs/stats.js
+++ b/libs/stats.js
@@ -301,6 +301,7 @@ console.log('ERROR FROM STATS.JS ' + err);
                                 validShares: replies[i + 2] ? (replies[i + 2].validShares || 0) : 0,
                                 validBlocks: replies[i + 2] ? (replies[i + 2].validBlocks || 0) : 0,
                                 invalidShares: replies[i + 2] ? (replies[i + 2].invalidShares || 0) : 0,
+                                invalidRate: ((replies[i + 2] ? (replies[i + 2].invalidShares || 0) : 0) / (replies[i + 2] ? (replies[i + 2].validShares || 0) : 0)).toFixed(4),
                                 totalPaid: replies[i + 2] ? (replies[i + 2].totalPaid || 0) : 0
                             },
                             blocks: {

--- a/website/pages/stats.html
+++ b/website/pages/stats.html
@@ -90,7 +90,7 @@
                                                                 <tr>
                                                                         <th>Pool</th>
                                                                         <th>Valid Shares</th>
-                                                                        <th>Invalid Shares</th>
+                                                                        <th>Invalid Shares (Rate %)</th>
                                                                         <th>Total Blocks</th>
                                                                 </tr>
                                                         </thead>
@@ -99,7 +99,7 @@
 								<tr>
 									<td>{{=pool}}</td>
 									<td>{{=it.stats.pools[pool].poolStats.validShares}}</td>
-									<td>{{=it.stats.pools[pool].poolStats.invalidShares}}</td>
+									<td>{{=it.stats.pools[pool].poolStats.invalidShares}} ({{=it.stats.pools[pool].poolStats.invalidRate}}%)</td>
 									<td>{{=it.stats.pools[pool].poolStats.validBlocks}}</td>
 								</tr>
 					                {{ } }}


### PR DESCRIPTION
This will add an invalid rate percentage on the stats page for those who want to get an idea of their error rate. This gives it some magnitude even when the numbers climb.